### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ bintray {
 
 ## 其他技巧
 
-###跳过自动构建
+### 跳过自动构建
 如果commit不想让travis ci构建，那么就在commit message里加上`[ci skip]`就行了。
 ```cmd
 git commit -m "[ci skip] commit message"


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
